### PR TITLE
Fix segfault in get_selected_window() since python 2.7.10

### DIFF
--- a/escrotum/utils.py
+++ b/escrotum/utils.py
@@ -8,10 +8,12 @@ def get_selected_window():
     from: http://unix.stackexchange.com/a/16157
     """
 
-    from ctypes import CDLL, c_int, c_uint32, c_uint, byref
+    from ctypes import CDLL, c_int, c_uint32, c_uint, byref, c_void_p
 
     Xlib = CDLL("libX11.so.6")
-    display = Xlib.XOpenDisplay(None)
+    Xlib.XOpenDisplay.restype = c_void_p
+
+    display = c_void_p(Xlib.XOpenDisplay(None))
 
     if display == 0:
         return None


### PR DESCRIPTION
With the new python 2.7.10 release, in 64 bit platforms, ctypes started
guessing the return value of XOpenDisplay() as a 32 bit int instead of a
64 bit void *, which truncated the pointer and resulted in segfaults
when passing it to the next functions.

Fixed by telling ctypes the return value type (which avoids truncation
before we even get it), and turning the display variable into a c_void_p
(which avoids truncation when passing it to the following functions)